### PR TITLE
Feature vcluster migrate backup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 Cargo.lock
 *.code-workspace
 *.log
+.idea/

--- a/README.md
+++ b/README.md
@@ -82,6 +82,35 @@ chmod 777 -R /var/log/manta
 | sites.site_name.vault_secret_path   | yes         | config file                   | path in vault to find secrets                                                                                                                                        | shasta | prealps                      |
 | sites.site_name.shasta_base_url     | yes         | config file                   | Shasta API base URL for Shasta related jobs submission                                                                                                               | https://api-gw-service-nmn.local/apis |
 
+### A note on certificates
+
+Manta expects to have the CA of the CSM endpoint in PEM format in a file named `<SITE>_root_cert.pem>` under `${HOME}/.config/manta` (Linux) or `${HOME}/Library/Application\ Support/local.cscs.manta` (MacOS).
+Please make sure **the file contains just one CA**, on MacOS if there are more than one in the file, and the native-tls module is used, the following part of the security framework crate will break Manta:
+```rust
+    #[cfg(not(target_os = "ios"))]
+pub fn from_pem(buf: &[u8]) -> Result<Certificate, Error> {
+    let mut items = SecItems::default();
+    ImportOptions::new().items(&mut items).import(buf)?;
+    if items.certificates.len() == 1 && items.identities.is_empty() && items.keys.is_empty() {
+        Ok(Certificate(items.certificates.pop().unwrap()))
+    } else {
+        Err(Error(base::Error::from(errSecParam)))
+    }
+}
+```
+
+The error message thrown is usually difficult to interpret and is something like:
+```
+thread 'main' panicked at <somepath>/mesa/src/shasta/authentication.rs:65:10:
+called `Result::unwrap()` on an `Err` value: reqwest::Error { kind: Builder, source: Error { code: -50, message: "One or more parameters passed to a function were not valid." } }
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+```
+
+It's easy to determine how many certs are in the file with `openssl`:
+```bash
+while openssl x509 -noout -subject; do :; done < ~/.config/manta/alps_root_cert.2certsin1.pem
+```
+
 ## Example
 
 ### Get latest (most recent) session

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Manta aggregates information from multiple sources:
 
 ## Configuration
 
-Manta needs a configuration file in `$HOME/.config/manta/config.toml` like shown below
+Manta needs a configuration file in `${HOME}/.config/manta/config.toml` like shown below
 
 ```bash
 log = "info"
@@ -58,7 +58,7 @@ vault_secret_path = "shasta"
 vault_role_id = "b15517de-cabb-06ba-af98-633d216c6d99" # vault in hashicorp-vault.cscs.ch
 ```
 
-Manta can log user's operations in /var/log/manta/ folder, please make sure this folder exists and all users have rwx access to it
+Manta can log user's operations in `/var/log/manta/` (Linux) or `${PWD}` (MacOS), please make sure this folder exists and the current user has `rwx` access to it
 
 ```bash
 mkdir /var/log/manta

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -1,4 +1,4 @@
-use clap::{arg, value_parser, ArgAction, ArgGroup, Command};
+use clap::{arg, value_parser, ArgAction, ArgGroup, Command, Arg};
 
 use std::path::PathBuf;
 
@@ -34,6 +34,14 @@ pub fn build_cli(hsm_group: Option<&String>) -> Command {
                 // .arg(arg!(-p --"public-ssh-key-id" <PUBLIC_SSH_ID> "Public ssh key id stored in Alps"))
                 .arg(arg!(-i --"image-id" <IMAGE_ID> "Image ID to use as a container image").required(true))
                             ),
+        )
+        .subcommand(
+            Command::new("migrate")
+                .alias("m")
+                .arg_required_else_help(true)
+                .about("Migrate vCluster")
+                .subcommand(subcommand_migrate_backup())
+                .subcommand(subcommand_migrate_restore()),
         )
         .subcommand(
             Command::new("update")
@@ -560,4 +568,69 @@ pub fn subcommand_update_hsm_group(hsm_group: Option<&String>) -> Command {
     };
 
     update_hsm_group
+}
+
+pub fn subcommand_migrate_backup() -> Command {
+    let mut migrate_backup = Command::new("backup")
+        .aliases(["mb"])
+        .arg_required_else_help(true)
+        .about("Backup/restore the configuration of a given vCluster.")
+        .arg(arg!(-b --"bos" <SESSIONTEMPLATE> "BOS Sessiontemplate to use to derive CFS, boot parameters and HSM group"))
+        .arg(arg!(-d --"destination" <FOLDER> "Destination folder to store the backup on"));
+
+    // .arg(Arg::new("destination")
+    //     .long("destination")
+    //     .short('d')
+    //     .help("Destination folder to store the backup on")
+    //     .required(true)
+    //     .id("destination"))
+    // .arg(Arg::new("bos")
+    //     .short('b')
+    //     .long("bos-sessiontemplate")
+    //     .help("BOS session template to use to derive CFS, boot parameters and HSM group(s)")
+    //     .required(true)
+    //     .id("bos"));
+    // TODO show the full help when running manta migrate --help
+    // .arg(arg!(-b --"bos-sessiontemplate" <SESSIONTEMPLATE> "BOS Sessiontemplate to use to derive CFS, boot parameters and HSM group"));
+    // .arg(arg!(-d --"destination" <FOLDER> "Destination folder to store the backup on"))
+    // migrate_backup = migrate_backup
+    //     .group(ArgGroup::new("configuration_limit").args(["most-recent", "limit"]));
+
+    // long"("os-sessiontemplate" <SESSIONTEMPLATE> "BOS Sessiontemplate to use to derive CFS, boot parameters and HSM group"))
+    // migrate_backup = match migrate_backup {
+    //     Some(_) => {
+    //         migrate_backup
+    //             .arg(arg!(-l --"ansible-limit" <VALUE> "Ansible limit. Target xnames to the CFS session. Note: ansible-limit must be a subset of hsm-group if both parameters are provided").required(true))
+    //     }
+    //     None => {
+    //         migrate_backup
+    //             .arg(arg!(-d --"destination" <FOLDER> "Destination folder to store the backup on"))
+    //             .arg(arg!(-b --"bos-sessiontemplate" <SESSIONTEMPLATE> "BOS Sessiontemplate to use to derive CFS, boot parameters and HSM group"))
+    //             .group(ArgGroup::new("hsm-group_or_ansible-limit").args(["hsm-group", "ansible-limit"]).required(true))
+    //     }
+    // };
+    // migrate_backup = match migrate_backup {
+    //     Some(_) => migrate_backup,
+    //     None => migrate_backup
+    //         .arg(arg!(<SESSIONTEMPLATE> "BOS sessiontemplate").required(true))
+    //         .arg(arg!(<FOLDER> "Destination folder").required(true)),
+    // };
+
+    migrate_backup
+}
+// TODO
+pub fn subcommand_migrate_restore() -> Command {
+    let mut migrate_restore = Command::new("restore")
+        .aliases(["mr"])
+        .arg_required_else_help(true)
+        .about("MIGRATE RESTORE of all the nodes in a HSM group. Boot configuration means updating the image used to boot the machine. Configuration of a node means the CFS configuration with the ansible scripts running once a node has been rebooted.\neg:\nmanta update hsm-group --boot-image <boot cfs configuration name> --desired-configuration <desired cfs configuration name>")
+        .arg(arg!(-b --"boot-image" <CFS_CONFIG> "CFS configuration name related to the image to boot the nodes"))
+        .arg(arg!(-d --"desired-configuration" <CFS_CONFIG> "CFS configuration name to configure the nodes after booting"));
+
+    // migrate_restore = match hsm_group {
+    //     Some(_) => update_hsm_group,
+    //     None => update_hsm_group.arg(arg!(<HSM_GROUP_NAME> "HSM group name").required(true)),
+    // };
+
+    migrate_restore
 }

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -22,5 +22,7 @@ pub mod get_nodes;
 pub mod get_session;
 pub mod get_template;
 pub mod log;
+pub mod migrate_backup;
+pub mod migrate_restore;
 pub mod update_hsm_group;
 pub mod update_node;

--- a/src/cli/commands/migrate_backup.rs
+++ b/src/cli/commands/migrate_backup.rs
@@ -1,0 +1,145 @@
+use std::path::Path;
+use mesa::shasta::{bos,cfs,ims};
+use mesa::manta;
+use std::io;
+use std::io::BufWriter;
+use std::fs::File;
+use std::fs;
+
+pub async fn exec(
+    shasta_token: &str,
+    shasta_base_url: &str,
+    shasta_root_cert: &[u8],
+    bos:  Option<&String>,
+    destination:  Option<&String>
+) {
+    println!("Migrate_backup; BOS Template={}, Destination folder={}",bos.unwrap(), destination.unwrap());
+    let dest_path = Path::new(destination.unwrap());
+    log::debug!("Create directory '{}'", destination.unwrap());
+    // TODO control return
+    std::fs::create_dir_all(dest_path);
+    let _empty_hsm_group_name: Vec<String> = Vec::new();
+    let bos_templates = bos::template::http_client::filter(
+        shasta_token,
+        shasta_base_url,
+        shasta_root_cert,
+        &_empty_hsm_group_name,
+        Option::from(bos.unwrap()),
+        None,
+    ).await.unwrap_or_default();
+
+    if bos_templates.is_empty() {
+        println!("No BOS template found!");
+        std::process::exit(0);
+    } else {
+        // BOS ------------------------------------------------------------------------------------
+        let mut bos_file_path= dest_path.join("bos.json");
+        let bos_file = File::create(bos_file_path)
+            .expect("bos.json file could not be created.");
+
+        // Save to file only the first one returned, we don't expect other BOS templates in the array
+        let bosjson = serde_json::to_writer(&bos_file, &bos_templates[0]);
+
+        // CFS ------------------------------------------------------------------------------------
+        let configuration_name  =  &bos_templates[0]["cfs"]["configuration"].to_owned().to_string();
+        let mut cn = configuration_name.chars();
+        cn.next();
+        cn.next_back();
+        // cn.as_str();
+        let crap = String::from(cn.as_str());
+        let cfs_configurations = manta::cfs::configuration::get_configuration(
+            shasta_token,
+            shasta_base_url,
+            shasta_root_cert,
+            Option::from(crap).as_ref(),
+            &_empty_hsm_group_name,
+            Option::from(true),
+            None,
+        ).await;
+        let mut cfs_file_path= dest_path.join("cfs.json");
+        let cfs_file = File::create(cfs_file_path)
+            .expect("cfs.json file could not be created.");
+        // Save to file only the first one returned, we don't expect other BOS templates in the array
+        let cfsjson = serde_json::to_writer(&cfs_file, &cfs_configurations[0]);
+
+        // Image ----------------------------------------------------------------------------------
+        for (_boot_sets_param, boot_sets_value) in bos_templates[0]["boot_sets"]
+            .as_object()
+            .unwrap()
+        {
+            if let Some(path) = boot_sets_value.get("path") {
+                let image_id_related_to_bos_sessiontemplate = path
+                    .as_str()
+                    .unwrap()
+                    .trim_start_matches("s3://boot-images/")
+                    .trim_end_matches("/manifest.json")
+                    .to_string();
+
+                log::info!(
+                    "Get image details for ID {}",
+                    image_id_related_to_bos_sessiontemplate
+                );
+
+                if ims::image::http_client::get(
+                    shasta_token,
+                    shasta_base_url,
+                    shasta_root_cert,
+                    &_empty_hsm_group_name,
+                    Some(&image_id_related_to_bos_sessiontemplate),
+                    None,
+                    None
+                )
+                    .await
+                    .is_ok()
+                {
+                    log::info!(
+                        "Image ID found related to BOS sessiontemplate {} is {}",
+                        bos_templates[0]["boot_sets"]["name"],
+                        image_id_related_to_bos_sessiontemplate
+                    );
+
+                };
+            }
+        }
+        bos::template::utils::print_table(bos_templates);
+    }
+
+    if  let destination = dest_path.is_dir() {
+        println!("is directory");
+    } else {
+        println!("is not directory");
+    }
+    // Extract in json format:
+    //  - the bos-session template
+    //  - the cfs configuration referred in the bos-session template
+    //  - the contents of the HSM group referred in the bos-session template
+
+
+
+    std::process::exit(0);
+}
+//     if let Some(true) = most_recent {
+//         limit_number = Some(&1);
+//     } else if let Some(false) = most_recent {
+//         limit_number = limit;
+//     } else {
+//         limit_number = None;
+//     }
+//
+//     let bos_templates = bos::template::http_client::get(
+//         shasta_token,
+//         shasta_base_url,
+//         hsm_group_name,
+//         template_name,
+//         limit_number,
+//     )
+//     .await
+//     .unwrap_or_default();
+//     if bos_templates.is_empty() {
+//
+//         println!("No BOS template found!");
+//         std::process::exit(0);
+//     } else {
+//         bos::template::utils::print_table(bos_templates);
+//     }
+// }

--- a/src/cli/commands/migrate_backup.rs
+++ b/src/cli/commands/migrate_backup.rs
@@ -1,16 +1,9 @@
 use std::collections::HashMap;
-use std::env::{current_dir, temp_dir};
 use std::path::Path;
-use mesa::shasta::{bos, cfs, hsm, ims};
+use mesa::shasta::{bos, hsm, ims};
 use mesa::manta;
-use std::io;
-use std::io::BufWriter;
 use std::fs::File;
-use std::fs;
-use std::ops::Deref;
 use mesa::shasta::ims::s3::s3::{s3_auth, s3_download_object};
-use serde_json::{Map, Value};
-use crate::common::{cluster_ops, node_ops};
 
 pub async fn exec(
     shasta_token: &str,
@@ -53,7 +46,7 @@ pub async fn exec(
         println!("Downloading BOS session template {} to {} [{}/{}]", &bos.unwrap(), &bos_file_path.clone().to_string_lossy(), &download_counter, &files2download.len()+3);
 
         // Save to file only the first one returned, we don't expect other BOS templates in the array
-        let bosjson = serde_json::to_writer(&bos_file, &bos_templates[0]);
+        let _bosjson = serde_json::to_writer(&bos_file, &bos_templates[0]);
         download_counter = download_counter + 1;
 
         // HSM group -----------------------------------------------------------------------------
@@ -70,8 +63,8 @@ pub async fn exec(
         let mut hsm_map = HashMap::new();
 
         for v3 in v2 {
-            let mut v4 = vec![v3.clone()];
-            let mut xnames: Vec<String> = hsm::utils::get_member_vec_from_hsm_name_vec(
+            let v4 = vec![v3.clone()];
+            let xnames: Vec<String> = hsm::utils::get_member_vec_from_hsm_name_vec(
                 shasta_token,
                 shasta_base_url,
                 shasta_root_cert,
@@ -81,10 +74,7 @@ pub async fn exec(
         }
         // println!("hsm_map={:?}", hsm_map);
 
-        let hsmjson = serde_json::to_writer(&hsm_file, &hsm_map);
-
-
-
+        let _hsmjson = serde_json::to_writer(&hsm_file, &hsm_map);
 
         // CFS ------------------------------------------------------------------------------------
         let configuration_name  =  &bos_templates[0]["cfs"]["configuration"].to_owned().to_string();
@@ -109,7 +99,7 @@ pub async fn exec(
         println!("Downloading CFS configuration {} to {} [{}/{}]", cn.clone().as_str(), &cfs_file_path.clone().to_string_lossy(), &download_counter, &files2download.len()+2);
 
         // Save to file only the first one returned, we don't expect other BOS templates in the array
-        let cfsjson = serde_json::to_writer(&cfs_file, &cfs_configurations[0]);
+        let _cfsjson = serde_json::to_writer(&cfs_file, &cfs_configurations[0]);
         download_counter = download_counter + 1;
 
         // Image ----------------------------------------------------------------------------------

--- a/src/cli/commands/migrate_backup.rs
+++ b/src/cli/commands/migrate_backup.rs
@@ -126,7 +126,7 @@ pub async fn exec(
                     for file in  files2download {
                         let dest = String::from(destination.unwrap()) + "/" + &image_id;
                         let src = image_id.clone() + "/" + file;
-                        println!("Downloading image file {} to {}/{} [{}/{}]", &src, &dest, &file, &download_counter, &files2download.len());
+                        println!("Downloading image file {} to {}/{} [{}/{}]", &src, &dest, &file, &download_counter, &files2download.len()+2);
                         let _result = match s3_download_object(&sts_value,
                                                                &src,
                                                                &bucket_name,

--- a/src/cli/commands/migrate_restore.rs
+++ b/src/cli/commands/migrate_restore.rs
@@ -1,0 +1,37 @@
+use mesa::shasta::bos;
+
+pub async fn exec(
+    shasta_token: &str,
+    shasta_base_url: &str,
+    hsm_group_name: Option<&String>,
+    template_name: Option<&String>,
+    most_recent: Option<bool>,
+    limit: Option<&u8>,
+) {
+    let limit_number;
+
+    if let Some(true) = most_recent {
+        limit_number = Some(&1);
+    } else if let Some(false) = most_recent {
+        limit_number = limit;
+    } else {
+        limit_number = None;
+    }
+    //
+    // let bos_templates = bos::template::http_client::get(
+    //     shasta_token,
+    //     shasta_base_url,
+    //     hsm_group_name,
+    //     template_name,
+    //     limit_number,
+    // )
+    //     .await
+    //     .unwrap_or_default();
+
+    // if bos_templates.is_empty() {
+    //     println!("No BOS template found!");
+    //     std::process::exit(0);
+    // } else {
+    //     bos::template::utils::print_table(bos_templates);
+    // }
+}

--- a/src/cli/process.rs
+++ b/src/cli/process.rs
@@ -23,7 +23,7 @@ use super::commands::{
     apply_node_on, apply_node_reset, apply_session, config_set_hsm, config_set_log,
     config_set_site, config_show, config_unset_auth, config_unset_hsm,
     console_cfs_session_image_target_ansible, console_node, get_configuration, get_hsm, get_images,
-    get_nodes, get_session, get_template, update_hsm_group, update_node,
+    get_nodes, get_session, get_template, update_hsm_group, update_node, migrate_backup, migrate_restore,
 };
 
 pub async fn process_cli(
@@ -673,7 +673,7 @@ pub async fn process_cli(
                     k8s_api_url,
                     cli_console_node.get_one::<String>("XNAME").unwrap(),
                 )
-                .await;
+                    .await;
             } else if let Some(cli_console_target_ansible) =
                 cli_console.subcommand_matches("target-ansible")
             {
@@ -694,7 +694,7 @@ pub async fn process_cli(
                         shasta_base_url,
                         shasta_root_cert,
                     )
-                    .await
+                        .await
                 };
 
                 console_cfs_session_image_target_ansible::exec(
@@ -711,7 +711,21 @@ pub async fn process_cli(
                         .get_one::<String>("SESSION_NAME")
                         .unwrap(),
                 )
-                .await;
+                    .await;
+            }
+        } else if let Some(cli_migrate) = cli_root.subcommand_matches("migrate") {
+            if let Some(cli_migrate) = cli_migrate.subcommand_matches("backup") {
+                let bos = cli_migrate.get_one::<String>("bos");
+                let destination = cli_migrate.get_one::<String>("destination");
+                migrate_backup::exec(
+                    shasta_token,
+                    shasta_base_url,
+                    shasta_root_cert,
+                    bos,
+                    destination
+                ).await;
+            } else if let Some(cli_migrate) = cli_migrate.subcommand_matches("restore")  {
+                log::info!(">>> MIGRATE RESTORE not implemented yet")
             }
         } else if let Some(cli_delete) = cli_root.subcommand_matches("delete") {
             let hsm_name_available_vec = if let Some(hsm_name) = hsm_group_name_opt {


### PR DESCRIPTION
I think the backup of a vCluster is complete in terms of BOS, CFS configuration, image contents, and HSM contents. I'd leave as TODO the integration with `clstr` to produce a hardware-descriptive pattern of the nodes used in the different HSM groups.

This is a partial PR, the restore part is still a work in progress.