### PR TITLE
Fix typo on Docs

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -169,7 +169,7 @@ $ manta set runtime-configuration -H my_cluster -c my_configuration
 
 **Q: How to list all sessions in the system?**
 
-**A:** `mange get sessions`
+**A:** `manta get sessions`
 
 ---
 


### PR DESCRIPTION
fix typo mange -> manta

Cheers, from Nicolas kowenski (ETHz)