### PR TITLE
cli.toml: make site field optional and remove [sites] table

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -102,7 +102,7 @@ manta config set hsm compute
 
 ### config set site \<SITE_NAME\>
 
-Set the active site (must match a `[sites.<name>]` entry in config).
+Set the active site, persisted as `site = "..."` in `cli.toml` and sent as the `X-Manta-Site` header. The server validates it against its configured sites; the CLI does no local validation.
 
 ```
 manta config set site cscs_prod

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ mkdir -p "$CONFIG_DIR"
 cat > "$CONFIG_DIR/cli.toml" <<'EOF'
 log              = "info"
 site             = "ochami"
-parent_hsm_group = "nodes_free"
+hsm_group        = "nodes_free"
 manta_server_url = "https://manta-server.example.com:8443"   # required
 EOF
 # server.toml is site-specific (TLS certs + per-site backend URLs) —
@@ -150,7 +150,7 @@ cat > "$CONFIG_DIR/cli.toml" <<EOF
 log = "info"
 
 site = "ochami"
-parent_hsm_group = "nodes_free"
+hsm_group = "nodes_free"
 manta_server_url = "https://manta-server.example.com:8443"   # required
 EOF
 ```
@@ -249,7 +249,7 @@ Manta reads two TOML files, one per binary: `cli.toml` for the CLI and `server.t
 
 Override the path with `MANTA_CLI_CONFIG` / `MANTA_SERVER_CONFIG`.
 
-The two schemas are **disjoint**: the CLI's `cli.toml` carries only the CLI-side knobs (`site`, `parent_hsm_group`, `manta_server_url`, optional `socks5_proxy`) — it has **no `[sites.*]` block** and no Kafka audit block (audit emission is server-side only). Every per-site backend connection detail (URLs, TLS certs, k8s, vault, per-site SOCKS proxies) lives in `server.toml`, alongside the `[server]` block (TLS, listen address, console timeout, auth rate limit) and the optional `[auditor.kafka]` for the server-side audit stream.
+The two schemas are **disjoint**: the CLI's `cli.toml` carries only the CLI-side knobs (`site`, `hsm_group`, `manta_server_url`, optional `socks5_proxy`) — it has **no `[sites.*]` block** and no Kafka audit block (audit emission is server-side only). Every per-site backend connection detail (URLs, TLS certs, k8s, vault, per-site SOCKS proxies) lives in `server.toml`, alongside the `[server]` block (TLS, listen address, console timeout, auth rate limit) and the optional `[auditor.kafka]` for the server-side audit stream.
 
 **`cli.toml`**
 

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ The two schemas are **disjoint**: the CLI's `cli.toml` carries only the CLI-side
 ```toml
 log = "info"
 
-site             = "alps"                                # active site (X-Manta-Site header)
+site             = "alps"                                # optional: active site (X-Manta-Site header); omit and pass --site per invocation
 manta_server_url     = "https://manta-server.cscs.ch:8443"   # required
 socks5_proxy         = "socks5h://127.0.0.1:1080"            # optional: reaches manta-server
 request_timeout_secs = 600                                   # optional: per-request HTTP timeout (seconds). Default 300 for REST calls; streams (SSE log tail, WS console) unlimited. Setting this also caps streams — pick a value larger than your worst-case session if you set it.

--- a/crates/manta-cli/src/common/app_context.rs
+++ b/crates/manta-cli/src/common/app_context.rs
@@ -11,9 +11,13 @@ use config::Config;
 /// handlers and commands.
 #[derive(Debug)]
 pub struct AppContext<'a> {
-  /// Site name used to set the `X-Manta-Site` header on outbound
-  /// `MantaClient` requests.
-  pub site_name: &'a str,
+  /// Resolved site (`--site` override, else `cli.toml`'s `site`), or
+  /// `None` when neither was supplied. It's just the `X-Manta-Site`
+  /// header on outbound `MantaClient` requests; commands that reach
+  /// the server obtain it via [`AppContext::require_site`]. The
+  /// purely-local `config set`/`config unset` commands never call
+  /// that, so they work with no site configured.
+  pub site_name: Option<&'a str>,
   /// URL of the manta HTTP server this CLI talks to. Required.
   pub manta_server_url: &'a str,
   /// Optional default group name from `cli.toml`'s
@@ -50,4 +54,55 @@ pub struct AppContext<'a> {
   /// `crate::dispatch::process::process_cli` consults this before
   /// allowing any mutating verb to dispatch.
   pub read_only: bool,
+}
+
+impl<'a> AppContext<'a> {
+  /// The site this invocation targets, or a user-facing error when
+  /// neither `--site` nor `cli.toml`'s `site` was supplied. Call this
+  /// at every point that needs to issue a request to `manta-server`;
+  /// commands that touch only the local config file must not.
+  pub fn require_site(&self) -> anyhow::Result<&'a str> {
+    self.site_name.ok_or_else(|| {
+      anyhow::anyhow!(
+        "No site selected. Pass --site <name> or set `site` in cli.toml"
+      )
+    })
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn ctx_with_site(site: Option<&'static str>) -> AppContext<'static> {
+    // `settings` is borrowed, so leak a default Config for the test's
+    // lifetime — cheap and avoids threading a real cli.toml through.
+    let settings: &'static Config = Box::leak(Box::new(Config::default()));
+    AppContext {
+      site_name: site,
+      manta_server_url: "https://example:8443",
+      settings_group_name_opt: None,
+      request_timeout_secs: None,
+      power_poll_interval_secs: None,
+      power_max_poll_attempts: None,
+      sat_file_poll_interval_secs: None,
+      sat_file_poll_budget_secs: None,
+      sat_file_not_visible_budget_secs: None,
+      settings,
+      read_only: false,
+    }
+  }
+
+  #[test]
+  fn require_site_returns_the_name_when_set() {
+    let ctx = ctx_with_site(Some("alps"));
+    assert_eq!(ctx.require_site().unwrap(), "alps");
+  }
+
+  #[test]
+  fn require_site_errors_when_unset() {
+    let ctx = ctx_with_site(None);
+    let err = ctx.require_site().unwrap_err().to_string();
+    assert!(err.contains("No site selected"), "got: {err}");
+  }
 }

--- a/crates/manta-cli/src/common/authentication.rs
+++ b/crates/manta-cli/src/common/authentication.rs
@@ -71,13 +71,13 @@ where
 /// Obtain a valid API token, trying in order: env var
 /// `MANTA_CSM_TOKEN`, cached file, interactive login. Every candidate
 /// is validated through `manta-server`.
-#[tracing::instrument(skip_all, fields(site = %ctx.site_name))]
+#[tracing::instrument(skip_all, fields(site = ctx.site_name.unwrap_or("<unset>")))]
 pub async fn get_api_token(ctx: &AppContext<'_>) -> Result<String> {
   // Auth endpoints are the ones that *obtain* or *check* the token,
   // so we pass `None` as the bearer here; no default `Authorization`
   // header gets attached.
-  let client = MantaClient::new(ctx.manta_server_url, ctx.site_name)?;
-  let site_name = ctx.site_name;
+  let site_name = ctx.require_site()?;
+  let client = MantaClient::new(ctx.manta_server_url, site_name)?;
 
   tracing::info!(
     server = %ctx.manta_server_url,

--- a/crates/manta-cli/src/common/config.rs
+++ b/crates/manta-cli/src/common/config.rs
@@ -20,7 +20,7 @@ pub struct CliConfiguration {
   /// request to manta-server. Overridable per-invocation with `--site`.
   /// The server validates that the name matches one of its configured
   /// sites; the CLI does no local validation.
-  pub site: String,
+  pub site: Option<String>,
   /// When `true`, the CLI refuses backend-mutating verbs (`add`,
   /// `apply`, `delete`, `migrate`, `power`, `run`, `restore`)
   /// before any HTTP request leaves the process. Toggled by
@@ -86,7 +86,7 @@ mod tests {
   fn cli_configuration_roundtrip_toml_minimal() {
     let cfg = CliConfiguration {
       log: "info".to_string(),
-      site: "alps".to_string(),
+      site: Some("alps".to_string()),
       read_only: false,
       manta_server_url: "https://manta-server.cscs.ch:8443".to_string(),
       socks5_proxy: Some("socks5h://127.0.0.1:1080".to_string()),
@@ -99,12 +99,22 @@ mod tests {
     };
     let toml_str = toml::to_string(&cfg).unwrap();
     let parsed: CliConfiguration = toml::from_str(&toml_str).unwrap();
-    assert_eq!(parsed.site, "alps");
+    assert_eq!(parsed.site.as_deref(), Some("alps"));
     assert_eq!(parsed.manta_server_url, "https://manta-server.cscs.ch:8443");
     assert_eq!(
       parsed.socks5_proxy.as_deref(),
       Some("socks5h://127.0.0.1:1080")
     );
+  }
+
+  #[test]
+  fn cli_configuration_site_optional() {
+    let toml_str = r#"
+      log = "info"
+      manta_server_url = "https://manta-server.cscs.ch:8443"
+    "#;
+    let parsed: CliConfiguration = toml::from_str(toml_str).unwrap();
+    assert!(parsed.site.is_none());
   }
 
   #[test]

--- a/crates/manta-cli/src/dispatch/config/mod.rs
+++ b/crates/manta-cli/src/dispatch/config/mod.rs
@@ -23,10 +23,17 @@ pub async fn handle_config(
 ) -> Result<(), Error> {
   match cli_config.subcommand() {
     Some(("show", m)) => {
-      let token = get_api_token(ctx).await?;
-      let client = MantaClient::from_app_ctx(ctx, Some(&token))?;
       let output_opt = m.opt_str("output");
-      show::exec(&client, &token, ctx.settings, output_opt).await?;
+      // `config show` is mostly local config, so it works without a
+      // site. Only when one is selected do we authenticate and build a
+      // client to fetch the per-site list of available groups.
+      let client = if ctx.site_name.is_some() {
+        let token = get_api_token(ctx).await?;
+        Some(MantaClient::from_app_ctx(ctx, Some(&token))?)
+      } else {
+        None
+      };
+      show::exec(client.as_ref(), ctx.settings, output_opt).await?;
     }
     Some(("set", m)) => match m.subcommand() {
       Some(("hsm", m)) => {

--- a/crates/manta-cli/src/dispatch/config/set_site.rs
+++ b/crates/manta-cli/src/dispatch/config/set_site.rs
@@ -1,8 +1,8 @@
 //! Implements the `manta config set site` command.
 
-use anyhow::{Context, Error, bail};
+use anyhow::{Context, Error};
 use clap::ArgMatches;
-use toml_edit::{Table, value};
+use toml_edit::value;
 
 use crate::output::action_result;
 use manta_shared::common::config::{read_config_toml, write_config_toml};
@@ -19,22 +19,11 @@ pub fn exec(cli_config_set_site: &ArgMatches) -> Result<(), Error> {
 fn set_site(new_site_opt: Option<&str>) -> Result<(), Error> {
   let (path, mut doc) = read_config_toml()?;
 
-  let site_available_table = doc["sites"]
-    .as_table()
-    .context("No 'sites' table in configuration file")?;
-
-  // VALIDATION
-  if site_available_table.is_empty() {
-    bail!("No 'sites' in config file");
-  }
-
-  validate_site_and_site_available_config_params(
-    new_site_opt.context("Site name argument is required")?,
-    site_available_table,
-  )?;
-
   let new_site = new_site_opt.context("Site name argument is required")?;
 
+  // The server is the source of truth for valid sites — the CLI does no
+  // local validation. Write the name; the server rejects an unknown site
+  // on the next request that carries it via the `X-Manta-Site` header.
   tracing::info!("Changing configuration to use 'site' {}", new_site);
 
   doc["site"] = value(new_site);
@@ -47,26 +36,6 @@ fn set_site(new_site_opt: Option<&str>) -> Result<(), Error> {
     tracing::error!(
       "'site' key missing from config after \
        writing — this should not happen"
-    );
-  }
-
-  Ok(())
-}
-
-fn validate_site_and_site_available_config_params(
-  site: &str,
-  site_available_table: &Table,
-) -> Result<(), Error> {
-  if !site_available_table.contains_key(site) {
-    bail!(
-      "Site provided ({}) not valid. Please \
-       choose one from the list below:\n{}",
-      site,
-      site_available_table
-        .iter()
-        .map(|(key, _value)| key.to_string())
-        .collect::<Vec<String>>()
-        .join(", ")
     );
   }
 

--- a/crates/manta-cli/src/dispatch/config/show.rs
+++ b/crates/manta-cli/src/dispatch/config/show.rs
@@ -8,18 +8,13 @@ use crate::output::config_summary::{self, ConfigSummary};
 use manta_shared::common::config::get_cli_config_file_path;
 
 /// Display the current manta configuration.
+///
+/// `client` is `Some` only when a site was selected (`--site` or
+/// `cli.toml`'s `site`); without one we still print the local config,
+/// just without the per-site, server-derived fields (available groups,
+/// current site).
 pub async fn exec(
-  client: &MantaClient,
-  token: &str,
-  settings: &Config,
-  output_opt: Option<&str>,
-) -> Result<(), Error> {
-  show(client, Some(token.to_string()), settings, output_opt).await
-}
-
-async fn show(
-  client: &MantaClient,
-  shasta_token_opt: Option<String>,
+  client: Option<&MantaClient>,
   settings: &Config,
   output_opt: Option<&str>,
 ) -> Result<(), Error> {
@@ -28,7 +23,9 @@ async fn show(
     .unwrap_or_else(|_| "error".to_string());
   let settings_hsm_group = settings.get_string("hsm_group").unwrap_or_default();
 
-  let hsm_group_available_opt = if shasta_token_opt.is_some() {
+  // Available groups are per-site, so fetch them only when we have a
+  // site-bound (and authenticated) client.
+  let hsm_group_available_opt = if let Some(client) = client {
     match client
       .openapi
       .get_available_groups(client.site_name())
@@ -51,7 +48,7 @@ async fn show(
       |p| p.to_string_lossy().to_string(),
     ),
     log_level,
-    current_site: client.site_name().to_string(),
+    current_site: client.map(|c| c.site_name().to_string()),
     read_only: settings.get_bool("read_only").unwrap_or(false),
     groups_available: hsm_group_available_opt,
     current_hsm: settings_hsm_group,

--- a/crates/manta-cli/src/dispatch/config/show.rs
+++ b/crates/manta-cli/src/dispatch/config/show.rs
@@ -21,7 +21,12 @@ pub async fn exec(
   let log_level = settings
     .get_string("log")
     .unwrap_or_else(|_| "error".to_string());
-  let settings_hsm_group = settings.get_string("hsm_group").unwrap_or_default();
+  // Absent or empty `hsm_group` both mean "no default group selected",
+  // mirroring how `current_site` is `None` when unset.
+  let settings_hsm_group = settings
+    .get_string("hsm_group")
+    .ok()
+    .filter(|s| !s.is_empty());
 
   // Available groups are per-site, so fetch them only when we have a
   // site-bound (and authenticated) client.

--- a/crates/manta-cli/src/dispatch/config/show.rs
+++ b/crates/manta-cli/src/dispatch/config/show.rs
@@ -1,9 +1,7 @@
 //! Implements the `manta config show` command.
 
-use std::collections::HashMap;
-
-use anyhow::{Context, Error};
-use config::{Config, Value};
+use anyhow::Error;
+use config::Config;
 
 use crate::http_client::{MantaClient, OpenApiResultExt};
 use crate::output::config_summary::{self, ConfigSummary};
@@ -47,22 +45,13 @@ async fn show(
     None
   };
 
-  let site_table: HashMap<String, Value> = settings
-    .get_table("sites")
-    .context("'sites' table not found in config")?;
-
-  let site_name = settings
-    .get_string("site")
-    .context("'site' key not found in config")?;
-
   let summary = ConfigSummary {
     config_file: get_cli_config_file_path().map_or_else(
       |_| "<unknown>".to_string(),
       |p| p.to_string_lossy().to_string(),
     ),
     log_level,
-    sites: site_table.keys().cloned().collect(),
-    current_site: site_name,
+    current_site: client.site_name().to_string(),
     read_only: settings.get_bool("read_only").unwrap_or(false),
     groups_available: hsm_group_available_opt,
     current_hsm: settings_hsm_group,

--- a/crates/manta-cli/src/dispatch/delete/group.rs
+++ b/crates/manta-cli/src/dispatch/delete/group.rs
@@ -15,12 +15,15 @@ pub async fn exec(
   dry_run: bool,
   output_opt: Option<&str>,
 ) -> Result<(), Error> {
+  // A delete always targets a site; resolve it up front so even a
+  // dry-run fails fast when no site is selected.
+  let site = ctx.require_site()?;
+
   if dry_run {
     // DELETE has no JSON body — describe the request that would go to the
     // backend so the user can confirm label + force flag before committing.
     println!(
-      "Dry-run: would DELETE group '{label}' on site '{}' (force={force}); no backend call will be made.",
-      ctx.site_name,
+      "Dry-run: would DELETE group '{label}' on site '{site}' (force={force}); no backend call will be made.",
     );
     return Ok(());
   }

--- a/crates/manta-cli/src/http_client/client.rs
+++ b/crates/manta-cli/src/http_client/client.rs
@@ -259,7 +259,7 @@ impl MantaClient {
   ) -> anyhow::Result<Self> {
     Self::new_with_timeout(
       ctx.manta_server_url,
-      ctx.site_name,
+      ctx.require_site()?,
       ctx.request_timeout_secs,
       token,
     )

--- a/crates/manta-cli/src/main.rs
+++ b/crates/manta-cli/src/main.rs
@@ -60,7 +60,8 @@ fn run() -> core::result::Result<(), Box<dyn std::error::Error>> {
   let site_name: String = cli_matches
     .get_one::<String>("site")
     .cloned()
-    .unwrap_or_else(|| configuration.site.clone());
+    .or_else(|| configuration.site.clone())
+    .ok_or("No site selected. Pass --site <name> or set `site` in cli.toml")?;
 
   if let Some(socks_proxy) = &configuration.socks5_proxy
     && !socks_proxy.is_empty()

--- a/crates/manta-cli/src/main.rs
+++ b/crates/manta-cli/src/main.rs
@@ -54,14 +54,17 @@ fn run() -> core::result::Result<(), Box<dyn std::error::Error>> {
     .build()?;
 
   // Resolve the active site name (just a header value — the server
-  // validates it). Set the SOCKS5 proxy env var while we are still
-  // single-threaded; the proxy is used to reach manta-server, not the
-  // backends — per-site backend proxying is the server's concern.
-  let site_name: String = cli_matches
+  // validates it). Left `None` when neither `--site` nor `cli.toml`'s
+  // `site` is set; commands that reach the server raise the error
+  // lazily via `AppContext::require_site`, so purely-local config
+  // commands (e.g. `config set site`) still work with no site set.
+  // Set the SOCKS5 proxy env var while we are still single-threaded;
+  // the proxy is used to reach manta-server, not the backends —
+  // per-site backend proxying is the server's concern.
+  let site_name: Option<String> = cli_matches
     .get_one::<String>("site")
     .cloned()
-    .or_else(|| configuration.site.clone())
-    .ok_or("No site selected. Pass --site <name> or set `site` in cli.toml")?;
+    .or_else(|| configuration.site.clone());
 
   if let Some(socks_proxy) = &configuration.socks5_proxy
     && !socks_proxy.is_empty()
@@ -75,12 +78,13 @@ fn run() -> core::result::Result<(), Box<dyn std::error::Error>> {
   rt.block_on(run_cli(settings, configuration, site_name, cli_matches))
 }
 
-/// CLI startup — takes the resolved site name and forwards it on every
-/// request via the `X-Manta-Site` header.
+/// CLI startup — takes the resolved site name (`None` when unset) and
+/// forwards it on every server request via the `X-Manta-Site` header.
+/// Commands that need it but find `None` fail via `require_site`.
 async fn run_cli(
   settings: config::Config,
   configuration: CliConfiguration,
-  site_name: String,
+  site_name: Option<String>,
   cli_matches: ArgMatches,
 ) -> core::result::Result<(), Box<dyn std::error::Error>> {
   let log_level = settings
@@ -100,7 +104,7 @@ async fn run_cli(
   let manta_server_url = configuration.manta_server_url.as_str();
 
   let app_context = AppContext {
-    site_name: &site_name,
+    site_name: site_name.as_deref(),
     manta_server_url,
     settings_group_name_opt: settings_hsm_group_name_opt.as_deref(),
     request_timeout_secs: configuration.request_timeout_secs,

--- a/crates/manta-cli/src/output/config_summary.rs
+++ b/crates/manta-cli/src/output/config_summary.rs
@@ -31,8 +31,10 @@ pub struct ConfigSummary {
   /// HSM groups the bearer token is permitted to access; `None` when
   /// the server lookup failed.
   pub groups_available: Option<Vec<String>>,
-  /// Active default HSM group from `hsm_group = "..."`.
-  pub current_hsm: String,
+  /// Active default HSM group from `hsm_group = "..."`. `None` when the
+  /// key is absent or empty — like `current_site`, it then renders as
+  /// `(unset)` in text and `null` in JSON.
+  pub current_hsm: Option<String>,
 }
 
 /// Render `summary` to stdout. Plain text by default (one line per
@@ -64,7 +66,10 @@ pub fn print(summary: &ConfigSummary, output_opt: Option<&str>) -> Result<()> {
       (None, Some(_)) => "Could not get list of groups available".to_string(),
     };
     println!("Groups available: {groups}");
-    println!("Current HSM: {}", summary.current_hsm);
+    println!(
+      "Current group: {}",
+      summary.current_hsm.as_deref().unwrap_or("(unset)")
+    );
   }
   Ok(())
 }
@@ -81,7 +86,7 @@ mod tests {
       current_site: Some("alps".to_string()),
       read_only: false,
       groups_available: Some(vec!["compute".to_string(), "uan".to_string()]),
-      current_hsm: "compute".to_string(),
+      current_hsm: Some("compute".to_string()),
     }
   }
 
@@ -124,6 +129,15 @@ mod tests {
     let json = serde_json::to_string(&s).unwrap();
     let v: Value = serde_json::from_str(&json).unwrap();
     assert!(v["current_site"].is_null());
+  }
+
+  #[test]
+  fn current_hsm_none_renders_as_null_in_json() {
+    let mut s = sample();
+    s.current_hsm = None;
+    let json = serde_json::to_string(&s).unwrap();
+    let v: Value = serde_json::from_str(&json).unwrap();
+    assert!(v["current_hsm"].is_null());
   }
 
   /// Text mode must not panic when no site is set; it prints a sentinel.

--- a/crates/manta-cli/src/output/config_summary.rs
+++ b/crates/manta-cli/src/output/config_summary.rs
@@ -21,7 +21,9 @@ pub struct ConfigSummary {
   pub log_level: String,
   /// The resolved active site for this invocation: the `--site`
   /// override when given, otherwise `site = "..."` from `cli.toml`.
-  pub current_site: String,
+  /// `None` when neither is set — `config show` still works without a
+  /// site, it just can't report one (serializes to `null` in JSON).
+  pub current_site: Option<String>,
   /// Mirror of `CliConfiguration.read_only`. When `true`, the
   /// chokepoint in `dispatch::process::process_cli` refuses
   /// backend-mutating verbs. See `crate::common::read_only`.
@@ -46,15 +48,21 @@ pub fn print(summary: &ConfigSummary, output_opt: Option<&str>) -> Result<()> {
   } else {
     println!("Configuration file: {}", summary.config_file);
     println!("Log level: {}", summary.log_level);
-    println!("Current site: {}", summary.current_site);
+    println!(
+      "Current site: {}",
+      summary.current_site.as_deref().unwrap_or("(unset)")
+    );
     println!(
       "Read-only: {}",
       if summary.read_only { "yes" } else { "no" }
     );
-    let groups = summary.groups_available.as_ref().map_or_else(
-      || "Could not get list of groups available".to_string(),
-      |v| v.join(", "),
-    );
+    let groups = match (&summary.groups_available, &summary.current_site) {
+      (Some(v), _) => v.join(", "),
+      // No site selected, so there was nothing to query — distinguish
+      // this from a genuine lookup failure against a selected site.
+      (None, None) => "(no site selected)".to_string(),
+      (None, Some(_)) => "Could not get list of groups available".to_string(),
+    };
     println!("Groups available: {groups}");
     println!("Current HSM: {}", summary.current_hsm);
   }
@@ -70,7 +78,7 @@ mod tests {
     ConfigSummary {
       config_file: "/home/u/.config/manta/cli.toml".to_string(),
       log_level: "info".to_string(),
-      current_site: "alps".to_string(),
+      current_site: Some("alps".to_string()),
       read_only: false,
       groups_available: Some(vec!["compute".to_string(), "uan".to_string()]),
       current_hsm: "compute".to_string(),
@@ -107,5 +115,22 @@ mod tests {
     let json = serde_json::to_string(&s).unwrap();
     let v: Value = serde_json::from_str(&json).unwrap();
     assert!(v["groups_available"].is_null());
+  }
+
+  #[test]
+  fn current_site_none_renders_as_null_in_json() {
+    let mut s = sample();
+    s.current_site = None;
+    let json = serde_json::to_string(&s).unwrap();
+    let v: Value = serde_json::from_str(&json).unwrap();
+    assert!(v["current_site"].is_null());
+  }
+
+  /// Text mode must not panic when no site is set; it prints a sentinel.
+  #[test]
+  fn text_mode_renders_with_no_site() {
+    let mut s = sample();
+    s.current_site = None;
+    print(&s, None).unwrap();
   }
 }

--- a/crates/manta-cli/src/output/config_summary.rs
+++ b/crates/manta-cli/src/output/config_summary.rs
@@ -19,9 +19,8 @@ pub struct ConfigSummary {
   pub config_file: String,
   /// `EnvFilter` directive string from `cli.toml`.
   pub log_level: String,
-  /// Names of every `[sites.X]` section in `cli.toml`.
-  pub sites: Vec<String>,
-  /// The site currently selected via `site = "..."` in `cli.toml`.
+  /// The resolved active site for this invocation: the `--site`
+  /// override when given, otherwise `site = "..."` from `cli.toml`.
   pub current_site: String,
   /// Mirror of `CliConfiguration.read_only`. When `true`, the
   /// chokepoint in `dispatch::process::process_cli` refuses
@@ -47,7 +46,6 @@ pub fn print(summary: &ConfigSummary, output_opt: Option<&str>) -> Result<()> {
   } else {
     println!("Configuration file: {}", summary.config_file);
     println!("Log level: {}", summary.log_level);
-    println!("Sites: {}", summary.sites.join(", "));
     println!("Current site: {}", summary.current_site);
     println!(
       "Read-only: {}",
@@ -72,7 +70,6 @@ mod tests {
     ConfigSummary {
       config_file: "/home/u/.config/manta/cli.toml".to_string(),
       log_level: "info".to_string(),
-      sites: vec!["alps".to_string(), "tasna".to_string()],
       current_site: "alps".to_string(),
       read_only: false,
       groups_available: Some(vec!["compute".to_string(), "uan".to_string()]),
@@ -97,7 +94,6 @@ mod tests {
     let v: Value = serde_json::from_str(&json).unwrap();
     assert_eq!(v["config_file"], "/home/u/.config/manta/cli.toml");
     assert_eq!(v["log_level"], "info");
-    assert_eq!(v["sites"][0], "alps");
     assert_eq!(v["current_site"], "alps");
     assert_eq!(v["read_only"], false);
     assert_eq!(v["groups_available"][0], "compute");

--- a/crates/manta-cli/tests/cli_tests.rs
+++ b/crates/manta-cli/tests/cli_tests.rs
@@ -1,5 +1,6 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
+use std::fs;
 
 #[test]
 fn cli_help_flag_succeeds() {
@@ -70,4 +71,81 @@ fn cli_apply_boot_group_help_uses_group_name_placeholder() {
     .success()
     .stdout(predicate::str::contains("<GROUP_NAME>"))
     .stdout(predicate::str::contains("CLUSTER_NAME").not());
+}
+
+/// Write a `cli.toml` with no `site` key into a fresh temp dir and
+/// return the dir (kept alive so it isn't deleted) and the file path.
+fn site_less_config() -> (tempfile::TempDir, std::path::PathBuf) {
+  let dir = tempfile::tempdir().unwrap();
+  let path = dir.path().join("cli.toml");
+  fs::write(
+    &path,
+    "log = \"info\"\n\
+     manta_server_url = \"https://manta-server.example.com:8443\"\n",
+  )
+  .unwrap();
+  (dir, path)
+}
+
+/// Bootstrap case: `config set site` must work even when no site is
+/// configured yet — it only writes the local config, never reaching
+/// the server.
+#[test]
+fn config_set_site_works_without_a_site_configured() {
+  let (_dir, path) = site_less_config();
+  Command::cargo_bin("manta")
+    .unwrap()
+    .env("MANTA_CLI_CONFIG", &path)
+    .args(["config", "set", "site", "mysite"])
+    .assert()
+    .success();
+  let written = fs::read_to_string(&path).unwrap();
+  assert!(
+    written.contains("site = \"mysite\""),
+    "config file should now carry the site key, got:\n{written}"
+  );
+}
+
+/// `config show` is mostly local config, so it works with no site —
+/// the site is reported as unset rather than erroring.
+#[test]
+fn config_show_works_without_a_site() {
+  let (_dir, path) = site_less_config();
+  Command::cargo_bin("manta")
+    .unwrap()
+    .env("MANTA_CLI_CONFIG", &path)
+    .args(["config", "show"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("Current site: (unset)"))
+    .stdout(predicate::str::contains(
+      "Groups available: (no site selected)",
+    ));
+}
+
+/// In JSON mode an unset site serializes to `null`, not an empty string.
+#[test]
+fn config_show_json_without_a_site_has_null_current_site() {
+  let (_dir, path) = site_less_config();
+  Command::cargo_bin("manta")
+    .unwrap()
+    .env("MANTA_CLI_CONFIG", &path)
+    .args(["config", "show", "--output", "json"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("\"current_site\":null"));
+}
+
+/// A command that reaches the backend must fail fast with a clear
+/// message when no site is selected — before any HTTP request.
+#[test]
+fn backend_command_without_a_site_errors_clearly() {
+  let (_dir, path) = site_less_config();
+  Command::cargo_bin("manta")
+    .unwrap()
+    .env("MANTA_CLI_CONFIG", &path)
+    .args(["get", "groups"])
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("No site selected"));
 }

--- a/crates/manta-shared/src/common/config/mod.rs
+++ b/crates/manta-shared/src/common/config/mod.rs
@@ -161,6 +161,8 @@ pub fn get_server_config_file_path() -> Result<PathBuf, Error> {
 
 /// Minimal CLI config sample shown in the NotFound error.
 const CLI_CONFIG_SAMPLE: &str = r#"log = "info"
+# Optional: the active site (`X-Manta-Site` header). Omit it and pass
+# `--site <name>` per invocation instead; the server validates the name.
 site = "<site_name>"
 manta_server_url = "https://manta-server.example.com:8443"
 

--- a/examples/cli.toml
+++ b/examples/cli.toml
@@ -8,6 +8,9 @@
 # Override the path with the `MANTA_CLI_CONFIG` env var.
 
 log = "info"
+# Optional: the active site, sent as the `X-Manta-Site` header. Omit it
+# and pass `--site <name>` per invocation instead. The server validates
+# the name against its configured sites.
 site = "alps"
 manta_server_url = "https://manta-server.example.com:8443"
 


### PR DESCRIPTION
 cli.toml required both a site = "..." key and a [sites] table. Neither should be mandatory — --site can supply the site per-invocation, and (in future) the server-side cache will resolve it.

**Breaking changes:**

- manta config show no longer prints a Sites: line, and --output json no longer includes the sites key.
- In `--output json`, `current_site` is now nullable — it serializes to `null` when no site is selected (previously always a string).

Closes #101 