### PR TITLE
fix(server): return 404 for unknown site on /auth/*  (#102)

### DIFF
--- a/crates/manta-cli/openapi.json
+++ b/crates/manta-cli/openapi.json
@@ -10,7 +10,7 @@
     "license": {
       "name": ""
     },
-    "version": "2.0.0-beta.55"
+    "version": "2.0.0-beta.61"
   },
   "servers": [
     {
@@ -128,6 +128,16 @@
               }
             }
           },
+          "404": {
+            "description": "Unknown site",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "429": {
             "description": "Rate limit exceeded",
             "content": {
@@ -185,6 +195,16 @@
           },
           "401": {
             "description": "Token rejected",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Unknown site",
             "content": {
               "application/json": {
                 "schema": {
@@ -4473,7 +4493,7 @@
     "schemas": {
       "AddHwComponentRequest": {
         "type": "object",
-        "description": "Request body for `POST /api/v1/hardware-clusters/{target}/members`.\n\nMoves nodes matching `pattern` out of `parent_cluster` and into\nthe path-level target cluster.",
+        "description": "Request body for `POST /api/v1/hardware-clusters/{target}/members`.\n\nMoves nodes matching `pattern` out of `parent_cluster` and into\nthe path-level target cluster. The reverse direction lives in\n[`DeleteHwComponentRequest`]; both operations are also expressible\nin unified form via [`ApplyHwConfigurationRequest`] with\n[`HwClusterMode::Pin`] vs [`HwClusterMode::Unpin`].",
         "required": [
           "parent_cluster",
           "pattern"
@@ -4538,7 +4558,7 @@
       },
       "AddNodeRequest": {
         "type": "object",
-        "description": "Request body for `POST /api/v1/nodes`.",
+        "description": "Request body for `POST /api/v1/nodes`.\n\nPaired with [`super::responses::AddNodeResponse`] on success.\n\n# Wire shape\n\n```json\n{\n  \"id\": \"x3000c0s1b0n0\",\n  \"group\": \"alps\",\n  \"enabled\": true,\n  \"arch\": \"X86\"\n}\n```",
         "required": [
           "id",
           "group"
@@ -4567,7 +4587,7 @@
       },
       "AddNodeResponse": {
         "type": "object",
-        "description": "Response for `POST /api/v1/nodes` — echoes the registered xname.",
+        "description": "Response for `POST /api/v1/nodes` — echoes the registered xname.\n\nPaired with [`super::node::AddNodeRequest`].\n\n# Wire shape\n\n```json\n{ \"id\": \"x3000c0s1b0n0\" }\n```",
         "required": [
           "id"
         ],
@@ -4580,7 +4600,7 @@
       },
       "AddNodesToGroupRequest": {
         "type": "object",
-        "description": "Request body for `POST /api/v1/groups/{name}/members`.",
+        "description": "Request body for `POST /api/v1/groups/{name}/members`.\n\nPaired with [`AddNodesToGroupResponse`] on success.",
         "required": [
           "hosts_expression"
         ],
@@ -4593,7 +4613,7 @@
       },
       "AddNodesToGroupResponse": {
         "type": "object",
-        "description": "Response body for `POST /api/v1/groups/{name}/members`.\n\nThe `removed` field name is retained for wire stability; its value\nis the final, sorted membership of the group after the update —\n**not** a list of removed nodes.",
+        "description": "Response body for `POST /api/v1/groups/{name}/members`.\n\nThe `removed` field name is retained for wire stability; its value\nis the final, sorted membership of the group after the update —\n**not** a list of removed nodes.\n\n`added` and `final_members` are both sorted alphabetically by xname.\n\n# Wire shape\n\n```json\n{\n  \"added\": [\"x3000c0s1b0n2\", \"x3000c0s1b0n3\"],\n  \"final_members\": [\"x3000c0s1b0n0\", \"x3000c0s1b0n1\", \"x3000c0s1b0n2\", \"x3000c0s1b0n3\"],\n  \"removed\": [\"x3000c0s1b0n0\", \"x3000c0s1b0n1\", \"x3000c0s1b0n2\", \"x3000c0s1b0n3\"]\n}\n```",
         "required": [
           "added",
           "final_members"
@@ -4604,7 +4624,7 @@
             "items": {
               "type": "string"
             },
-            "description": "Xnames that were added to the group as part of this request."
+            "description": "Xnames that were added to the group as part of this request,\nsorted alphabetically."
           },
           "final_members": {
             "type": "array",
@@ -4624,7 +4644,7 @@
       },
       "ApplyBootConfigRequest": {
         "type": "object",
-        "description": "Request body for `POST /api/v1/boot-config`.\n\nApplies a combined boot configuration (image + runtime config +\nkernel parameters) to the nodes named by `hosts_expression`. The\nfield is a hosts expression — xnames, NIDs, or hostlist notation;\nHSM group names are not accepted here (resolve them client-side\nfirst if needed).",
+        "description": "Request body for `POST /api/v1/boot-config`.\n\nApplies a combined boot configuration (image + runtime config +\nkernel parameters) to the nodes named by `hosts_expression`. The\nfield is a hosts expression — xnames, NIDs, or hostlist notation;\nHSM group names are not accepted here (resolve them client-side\nfirst if needed).\n\nAt least one of `boot_image_id`, `boot_image_configuration`,\n`kernel_parameters`, or `runtime_configuration` should be set;\n`null` fields are left unchanged on the targeted nodes.\n\n# Wire shape\n\n```json\n{\n  \"hosts_expression\": \"x3000c0s1b0n[0-3]\",\n  \"boot_image_id\": \"0a1b2c3d-...\",\n  \"boot_image_configuration\": null,\n  \"kernel_parameters\": \"console=ttyS0 nosmt\",\n  \"runtime_configuration\": \"cos-2.5\",\n  \"dry_run\": false\n}\n```",
         "required": [
           "hosts_expression"
         ],
@@ -4641,7 +4661,7 @@
               "string",
               "null"
             ],
-            "description": "IMS image ID to set as the boot image."
+            "description": "IMS image ID to set as the boot image. Mutually exclusive with\n`boot_image_configuration`: set one or the other, not both."
           },
           "dry_run": {
             "type": "boolean",
@@ -4703,7 +4723,7 @@
       },
       "ApplyKernelParametersRequest": {
         "type": "object",
-        "description": "Request body for `POST /api/v1/kernel-parameters/apply`.",
+        "description": "Request body for `POST /api/v1/kernel-parameters/apply`.\n\nOne of `xnames_expression` or `hsm_group` must be set (not both).\nThe chosen [`KernelParamOp`] determines what `params` means:\nmerge-keys, replace-set, or remove-set.\n\n# Wire shape\n\n```json\n{\n  \"xnames_expression\": \"x3000c0s1b0n[0-3]\",\n  \"hsm_group\": null,\n  \"operation\": \"add\",\n  \"params\": \"console=ttyS0 nosmt\",\n  \"overwrite\": false,\n  \"project_sbps\": true,\n  \"dry_run\": false\n}\n```",
         "required": [
           "operation",
           "params"
@@ -4747,7 +4767,7 @@
       },
       "AuthTokenRequest": {
         "type": "object",
-        "description": "Request body for `POST /api/v1/auth/token`.",
+        "description": "Request body for `POST /api/v1/auth/token`.\n\nPaired with [`AuthTokenResponse`] on success. The `/auth/*`\nsub-router is wrapped by `strip_body_for_logs`, so neither the\nrequest body nor the issued token appears in access logs.\n\n# Wire shape\n\n```json\n{ \"username\": \"alice\", \"password\": \"hunter2\" }\n```",
         "required": [
           "username",
           "password"
@@ -4765,7 +4785,7 @@
       },
       "AuthTokenResponse": {
         "type": "object",
-        "description": "Response body for `POST /api/v1/auth/token`.",
+        "description": "Response body for `POST /api/v1/auth/token`.\n\nReturned in exchange for a valid [`AuthTokenRequest`].\n\n# Wire shape\n\n```json\n{ \"token\": \"eyJhbGciOi...\" }\n```",
         "required": [
           "token"
         ],
@@ -4778,7 +4798,7 @@
       },
       "BackendSummary": {
         "type": "object",
-        "description": "One row of the backend-data summary, anchored on an IMS image.\n\nEvery IMS image visible to the caller produces exactly one row.\nThe row's `image_id` and `name` are always populated; the rest are\n`Option<String>` and are filled in only when the corresponding\nrelation resolves.",
+        "description": "One row of the backend-data summary, anchored on an IMS image.\n\nEvery IMS image visible to the caller produces exactly one row.\nThe row's `image_id` and `name` are always populated; the rest are\n`Option<String>` and are filled in only when the corresponding\nrelation resolves.\n\nSee also [`super::configuration_analysis::ConfigurationAnalysis`]\nfor the parallel configuration-centric projection.\n\n# Wire shape\n\n```json\n{\n  \"image_id\": \"0a1b2c3d-...\",\n  \"name\": \"compute-cos-2.5\",\n  \"image_created\": \"2026-05-12T10:14:22Z\",\n  \"configuration_name\": \"cos-2.5\",\n  \"safe_to_delete\": false\n}\n```",
         "required": [
           "image_id",
           "name",
@@ -4865,7 +4885,7 @@
       },
       "CompletedResponse": {
         "type": "object",
-        "description": "Response for endpoints that simply confirm a backup / restore /\nlong-running migrate operation finished. Emitted by\n`POST /api/v1/migrate/backup` and `POST /api/v1/migrate/restore`.",
+        "description": "Response for endpoints that simply confirm a backup / restore /\nlong-running migrate operation finished. Emitted by\n`POST /api/v1/migrate/backup` and `POST /api/v1/migrate/restore`.\n\n# Wire shape\n\n```json\n{ \"completed\": true }\n```",
         "required": [
           "completed"
         ],
@@ -4878,7 +4898,7 @@
       },
       "ConfigurationAnalysis": {
         "type": "object",
-        "description": "One row of the configuration-deletion-safety analysis.",
+        "description": "One row of the configuration-deletion-safety analysis.\n\nConfiguration-centric counterpart to\n[`super::analysis::BackendSummary`]; one entry per CFS\nconfiguration the caller can see.",
         "required": [
           "configuration",
           "safe_to_delete"
@@ -4950,7 +4970,7 @@
       },
       "CreateSessionRequest": {
         "type": "object",
-        "description": "Request body for `POST /api/v1/sessions`.\n\nThe CLI submits this when the user runs `manta run session`; the\nserver deserialises it in `handlers::session::create_session`.\n`repo_names` and `repo_last_commit_ids` are parallel-indexed —\n`repo_last_commit_ids[i]` is the commit SHA for `repo_names[i]`.",
+        "description": "Request body for `POST /api/v1/sessions`.\n\nThe CLI submits this when the user runs `manta run session`; the\nserver deserialises it in `handlers::session::create_session`.\n`repo_names` and `repo_last_commit_ids` are parallel-indexed —\n`repo_last_commit_ids[i]` is the commit SHA for `repo_names[i]`.\nThe two vectors must therefore have the same length.\n\nPaired with [`super::responses::CreateSessionResponse`].",
         "required": [
           "repo_names",
           "repo_last_commit_ids"
@@ -5016,7 +5036,7 @@
       },
       "CreateSessionResponse": {
         "type": "object",
-        "description": "Response for `POST /api/v1/sessions` — names of the created CFS\nsession and its underlying configuration.",
+        "description": "Response for `POST /api/v1/sessions` — names of the created CFS\nsession and its underlying configuration.\n\nPaired with [`super::session::CreateSessionRequest`]. When the\ncaller did not supply `cfs_conf_sess_name`, the server-generated\nname is echoed back here.",
         "required": [
           "session_name",
           "configuration_name"
@@ -5034,7 +5054,7 @@
       },
       "CreatedResponse": {
         "type": "object",
-        "description": "Response for endpoints that simply confirm a write happened.\n\nEmitted by `POST /api/v1/redfish-endpoints`,\n`POST /api/v1/boot-parameters`, and `POST /api/v1/groups`.",
+        "description": "Response for endpoints that simply confirm a write happened.\n\nEmitted by `POST /api/v1/redfish-endpoints`,\n`POST /api/v1/boot-parameters`, and `POST /api/v1/groups`.\n\n# Wire shape\n\n```json\n{ \"created\": true }\n```",
         "required": [
           "created"
         ],
@@ -5080,7 +5100,7 @@
       },
       "DeleteHwComponentRequest": {
         "type": "object",
-        "description": "Request body for `DELETE /api/v1/hardware-clusters/{target}/members`.",
+        "description": "Request body for `DELETE /api/v1/hardware-clusters/{target}/members`.\n\nReverse of [`AddHwComponentRequest`]: moves nodes matching\n`pattern` out of the path-level target cluster and back to\n`parent_cluster`.",
         "required": [
           "parent_cluster",
           "pattern"
@@ -5236,7 +5256,7 @@
       },
       "MigrateBackupRequest": {
         "type": "object",
-        "description": "Request body for `POST /api/v1/migrate/backup`.",
+        "description": "Request body for `POST /api/v1/migrate/backup`.\n\nPaired with [`super::responses::CompletedResponse`] on success.",
         "properties": {
           "bos": {
             "type": [
@@ -5290,7 +5310,7 @@
       },
       "MigrateNodesRequest": {
         "type": "object",
-        "description": "Request body for `POST /api/v1/migrate/nodes`.",
+        "description": "Request body for `POST /api/v1/migrate/nodes`.\n\nPaired with [`super::responses::MigrateNodesResponse`] on success.\n`target_hsm_names` and `parent_hsm_names` are length-matched: each\n`parent_hsm_names[i]` donates members to `target_hsm_names[i]`.\n\n# Wire shape\n\n```json\n{\n  \"target_hsm_names\": [\"zinal\"],\n  \"parent_hsm_names\": [\"alps\"],\n  \"hosts_expression\": \"x3000c0s1b0n[0-3]\",\n  \"dry_run\": false,\n  \"create_hsm_group\": false\n}\n```",
         "required": [
           "target_hsm_names",
           "parent_hsm_names",
@@ -5327,7 +5347,7 @@
       },
       "MigrateNodesResponse": {
         "type": "object",
-        "description": "Response for `POST /api/v1/migrate/nodes` — moved xnames plus a\nper-(target,parent) result list. Dry-run uses the same shape so the\nCLI consumes one type regardless of mode.",
+        "description": "Response for `POST /api/v1/migrate/nodes` — moved xnames plus a\nper-(target,parent) result list. Dry-run uses the same shape so the\nCLI consumes one type regardless of mode.\n\nPaired with [`super::migrate::MigrateNodesRequest`]. The `results`\narray runs in lockstep with the request's `target_hsm_names` /\n`parent_hsm_names` pairs.",
         "required": [
           "xnames",
           "results"
@@ -5351,7 +5371,7 @@
       },
       "MigrateRestoreRequest": {
         "type": "object",
-        "description": "Request body for `POST /api/v1/migrate/restore`.",
+        "description": "Request body for `POST /api/v1/migrate/restore`.\n\nPaired with [`super::responses::CompletedResponse`] on success.\nEvery `*_file` field is optional independently — supplying only\n`cfs_file` restores CFS configurations and leaves BOS, HSM, IMS,\nand image layers untouched.",
         "properties": {
           "bos_file": {
             "type": [
@@ -5396,7 +5416,7 @@
       },
       "NodeDetails": {
         "type": "object",
-        "description": "Per-node details returned by `GET /api/v1/nodes`.\n\nMirror of `csm_rs::node::types::NodeDetails` with identical fields\nand identical JSON wire format. No conversion impl is needed in\nthe server crate — the response is serialised straight from the\ncsm-rs type and the CLI deserialises it into this mirror.\n\nAll fields are wire-stringified (CSM serializes them that way);\ncallers parse them as needed for display or comparison.",
+        "description": "Per-node details returned by `GET /api/v1/nodes`.\n\nMirror of `csm_rs::node::types::NodeDetails` with identical fields\nand identical JSON wire format. No conversion impl is needed in\nthe server crate — the response is serialised straight from the\ncsm-rs type and the CLI deserialises it into this mirror.\n\nAll fields are wire-stringified (CSM serializes them that way);\ncallers parse them as needed for display or comparison. The empty\nstring is the conventional \"unset\" sentinel — see\n`cluster_status::compute_summary_status` for case-insensitive\nmatching on the status fields.\n\n# Wire shape\n\n```json\n{\n  \"xname\": \"x3000c0s1b0n0\",\n  \"nid\": \"nid001313\",\n  \"hsm\": \"alps,zinal\",\n  \"power_status\": \"On\",\n  \"desired_configuration\": \"cos-2.5\",\n  \"configuration_status\": \"configured\",\n  \"enabled\": \"true\",\n  \"error_count\": \"0\",\n  \"boot_image_id\": \"0a1b2c3d-...\",\n  \"boot_configuration\": \"cos-2.5\",\n  \"kernel_params\": \"console=ttyS0 ...\"\n}\n```",
         "required": [
           "xname",
           "nid",
@@ -5530,13 +5550,13 @@
         ],
         "properties": {
           "sat_file": {
-            "description": "Parsed SAT file content. Same shape as\n`PostSatConfigurationRequest::configuration` aggregated into\nthe full SAT document (`{ configurations, images,\nsession_templates, hardware }`)."
+            "description": "Parsed SAT file content — the **whole** SAT document, not a\nsingle entry. Sketch:\n\n```text\n{\n  \"configurations\":    [ {...}, ... ],   // entries of PostSatConfigurationRequest::configuration shape\n  \"images\":            [ {...}, ... ],   // entries of CreateImageCfsSessionRequest::image shape\n  \"session_templates\": [ {...}, ... ],   // entries of PostSatSessionTemplateRequest::session_template shape\n  \"hardware\":          [ {...}, ... ]\n}\n```"
           }
         }
       },
       "PostTemplateSessionRequest": {
         "type": "object",
-        "description": "Request body for `POST /api/v1/templates/{name}/sessions`.",
+        "description": "Request body for `POST /api/v1/templates/{name}/sessions`.\n\nCreates a BOS session from an existing session template (the\n`{name}` path segment).\n\n# Wire shape\n\n```json\n{\n  \"operation\": \"reboot\",\n  \"limit\": \"x3000c0s1b0n[0-3]\",\n  \"session_name\": null,\n  \"include_disabled\": false,\n  \"dry_run\": false\n}\n```",
         "required": [
           "operation",
           "limit"
@@ -5578,7 +5598,7 @@
       },
       "PowerRequest": {
         "type": "object",
-        "description": "Request body for `POST /api/v1/power`.",
+        "description": "Request body for `POST /api/v1/power`.\n\nThe interpretation of `host_expression` depends on [`PowerTargetType`];\nthe action itself is one of [`PowerAction`]'s variants.\n\n# Wire shape\n\n```json\n{\n  \"action\": \"on\",\n  \"host_expression\": \"x3000c0s1b0n[0-3]\",\n  \"target_type\": \"nodes\",\n  \"force\": false\n}\n```",
         "required": [
           "action",
           "host_expression",
@@ -5679,7 +5699,7 @@
       },
       "UpdateRedfishEndpointParams": {
         "type": "object",
-        "description": "Typed parameters for updating/adding a Redfish endpoint.",
+        "description": "Typed parameters for adding or updating a Redfish endpoint.\n\nShared request body for **both** `POST /redfish-endpoints` (add a\nnew endpoint) and `PUT /redfish-endpoints` (replace an existing\none by `id`). PUT is a full replacement — every field is written,\nso partial updates require reading the existing endpoint first.",
         "required": [
           "id",
           "enabled",
@@ -5775,7 +5795,7 @@
       },
       "ValidateTokenRequest": {
         "type": "object",
-        "description": "Request body for `POST /api/v1/auth/validate`.",
+        "description": "Request body for `POST /api/v1/auth/validate`.\n\nUsed to check a previously-issued [`AuthTokenResponse::token`]\nbefore relying on it. The server returns `200 OK` for a valid\ntoken and `401` otherwise — there is no dedicated response body.",
         "required": [
           "token"
         ],

--- a/crates/manta-cli/src/common/authentication.rs
+++ b/crates/manta-cli/src/common/authentication.rs
@@ -19,21 +19,27 @@
 //!    against `/api/v1/auth/token`. A successful interactive login is
 //!    written back to the cache file.
 //!
-//! ## Short-circuit on unreachable server
+//! ## Short-circuits
 //!
-//! If any step fails because the manta server itself is unreachable
-//! (DNS / TCP / TLS) — surfaced by the
-//! [`crate::http_client::AuthServerUnreachable`] typed context — the
-//! cascade aborts immediately. Trying the next path would hit the
-//! same dead endpoint, and re-prompting would only confuse the
-//! operator.
+//! Two failures abort the cascade immediately instead of falling
+//! through to the next path (or re-prompting), because no other
+//! credential source could possibly succeed:
+//!
+//! - **Unreachable server** (DNS / TCP / TLS) — surfaced by the
+//!   [`crate::http_client::AuthServerUnreachable`] typed context.
+//!   Trying the next path would hit the same dead endpoint.
+//! - **Unknown site** — a `404` from `/auth/*`, surfaced by the
+//!   [`crate::http_client::SiteNotFound`] typed context. The server is
+//!   reachable but doesn't serve the configured `site`; no token can
+//!   authenticate against a site that doesn't exist, so the cascade
+//!   stops rather than prompting for credentials.
 //!
 //! Non-interactive callers (`stdin` is not a TTY) also stop after the
 //! cached-token attempt rather than blocking on a prompt that can
 //! never be answered.
 
 use crate::common::app_context::AppContext;
-use crate::http_client::{AuthServerUnreachable, MantaClient};
+use crate::http_client::{AuthServerUnreachable, MantaClient, SiteNotFound};
 use crate::openapi_client::types::{AuthTokenRequest, ValidateTokenRequest};
 use anyhow::{Result, anyhow};
 use crossterm::style::Stylize;
@@ -60,6 +66,16 @@ fn is_auth_server_unreachable(err: &anyhow::Error) -> bool {
   err.downcast_ref::<AuthServerUnreachable>().is_some()
 }
 
+/// `true` if `err`'s typed-context chain contains [`SiteNotFound`] —
+/// the marker [`map_auth_error`] attaches on a `404` from `/auth/*`
+/// (the server is reachable but doesn't serve the configured site).
+/// Used by every stage of `get_api_token` to bail out instead of
+/// falling through to the next credential source or re-prompting:
+/// no credentials can authenticate against a site that doesn't exist.
+fn is_site_not_found(err: &anyhow::Error) -> bool {
+  err.downcast_ref::<SiteNotFound>().is_some()
+}
+
 /// Environment variable name for the API authentication token.
 const AUTH_TOKEN_ENV_VAR: &str = "MANTA_CSM_TOKEN";
 
@@ -70,15 +86,39 @@ const AUTH_CACHE_FILE_SUFFIX: &str = "_auth";
 const MAX_LOGIN_ATTEMPTS: u32 = 3;
 
 /// Wrap a progenitor `Error<E>` from an `/auth/*` call into an
-/// `anyhow::Error`, attaching the typed [`AuthServerUnreachable`]
-/// marker whenever the failure was at the TCP / timeout layer.
+/// `anyhow::Error`, attaching a typed marker that lets the caller tell
+/// the "keep trying" failures apart from the "stop now" ones:
+///
+/// - [`SiteNotFound`] on a `404` — the server is reachable but doesn't
+///   serve `site`; no credential can fix that.
+/// - [`AuthServerUnreachable`] on a TCP / timeout-layer failure — the
+///   manta server itself is unreachable.
+///
+/// Anything else is wrapped plain (a genuine credential rejection,
+/// which *should* fall through to the next attempt / re-prompt).
 fn map_auth_error<E: std::fmt::Debug>(
   err: progenitor_client::Error<E>,
   url: &str,
+  site: &str,
 ) -> anyhow::Error
 where
   progenitor_client::Error<E>: std::fmt::Display,
 {
+  // A reachable server that doesn't serve this site answers 404 (see
+  // manta-server's `/auth/*` handlers). Documented 404s arrive as
+  // `ErrorResponse`; an undocumented one as `UnexpectedResponse` —
+  // tag either, so the cascade short-circuits.
+  let status = match &err {
+    progenitor_client::Error::ErrorResponse(rv) => Some(rv.status()),
+    progenitor_client::Error::UnexpectedResponse(resp) => Some(resp.status()),
+    _ => None,
+  };
+  if status == Some(reqwest::StatusCode::NOT_FOUND) {
+    return anyhow!("{err}").context(SiteNotFound {
+      site: site.to_string(),
+    });
+  }
+
   let unreachable = match &err {
     progenitor_client::Error::CommunicationError(e) => {
       e.is_connect() || e.is_timeout()
@@ -139,6 +179,12 @@ pub async fn get_api_token(ctx: &AppContext<'_>) -> Result<String> {
       if is_auth_server_unreachable(&err) {
         return Err(err);
       }
+      // Likewise short-circuit on an unknown site: no token in any
+      // source can authenticate against a site the server doesn't
+      // serve, so don't fall through to the file/prompt stages.
+      if is_site_not_found(&err) {
+        return Err(err);
+      }
       tracing::warn!(
         error = %err,
         "env-var auth failed, trying cached token file"
@@ -153,6 +199,11 @@ pub async fn get_api_token(ctx: &AppContext<'_>) -> Result<String> {
     }
     Err(err) => {
       if is_auth_server_unreachable(&err) {
+        return Err(err);
+      }
+      // Unknown site: bail before prompting — the interactive login
+      // would 404 on every attempt.
+      if is_site_not_found(&err) {
         return Err(err);
       }
       let stdin = io::stdin();
@@ -218,7 +269,7 @@ async fn validate_token(
     )
     .await
     .map(|_| ())
-    .map_err(|e| map_auth_error(e, &url))
+    .map_err(|e| map_auth_error(e, &url, client.site_name()))
 }
 
 /// `POST /api/v1/auth/token` — exchange Keycloak credentials for a CSM
@@ -239,7 +290,7 @@ async fn get_token(
       },
     )
     .await
-    .map_err(|e| map_auth_error(e, &url))?;
+    .map_err(|e| map_auth_error(e, &url, client.site_name()))?;
   Ok(resp.into_inner().token)
 }
 
@@ -322,6 +373,15 @@ async fn get_token_interactively(client: &MantaClient) -> Result<String> {
         tracing::warn!(
           error = %err,
           "auth server unreachable; aborting interactive retries"
+        );
+        return shasta_token_rslt;
+      }
+      // An unknown site won't start existing on retry — stop after the
+      // first 404 instead of re-prompting for credentials.
+      if is_site_not_found(err) {
+        tracing::warn!(
+          error = %err,
+          "site not configured on server; aborting interactive retries"
         );
         return shasta_token_rslt;
       }
@@ -434,5 +494,26 @@ mod tests {
   #[test]
   fn max_login_attempts_is_reasonable() {
     const { assert!(MAX_LOGIN_ATTEMPTS >= 1 && MAX_LOGIN_ATTEMPTS <= 10) };
+  }
+
+  #[test]
+  fn site_not_found_marker_is_detected_through_anyhow_context() {
+    // The cascade's three bail-out points rely on `is_site_not_found`
+    // seeing the marker through anyhow's context wrapper — the same
+    // shape `map_auth_error` produces on a 404.
+    let err = anyhow!("HTTP 404").context(SiteNotFound {
+      site: "nonexistent".to_string(),
+    });
+    assert!(is_site_not_found(&err));
+    // Must not be confused with the unreachable-server short-circuit.
+    assert!(!is_auth_server_unreachable(&err));
+  }
+
+  #[test]
+  fn plain_error_is_not_site_not_found() {
+    // A genuine credential rejection carries no marker, so the cascade
+    // keeps trying / re-prompts rather than bailing.
+    let err = anyhow!("invalid credentials");
+    assert!(!is_site_not_found(&err));
   }
 }

--- a/crates/manta-cli/src/common/authentication.rs
+++ b/crates/manta-cli/src/common/authentication.rs
@@ -34,6 +34,13 @@
 //!   authenticate against a site that doesn't exist, so the cascade
 //!   stops rather than prompting for credentials.
 //!
+//!   Note: in the bare interactive case (no env var **and** no cache
+//!   file) the first server contact *is* the credential exchange, so
+//!   one prompt appears before the `404` can be seen; the short-circuit
+//!   then suppresses the remaining retries. Zero-prompt failure happens
+//!   only when an env-var or cached token gives the cascade something to
+//!   validate against the server *before* prompting.
+//!
 //! Non-interactive callers (`stdin` is not a TTY) also stop after the
 //! cached-token attempt rather than blocking on a prompt that can
 //! never be answered.

--- a/crates/manta-cli/src/http_client/client.rs
+++ b/crates/manta-cli/src/http_client/client.rs
@@ -57,6 +57,32 @@ impl std::fmt::Display for AuthServerUnreachable {
 
 impl std::error::Error for AuthServerUnreachable {}
 
+/// Marker error attached as anyhow context whenever an `/auth/*` HTTP
+/// call returns `404 Not Found` — the manta server is reachable but the
+/// `site` in your config isn't one it serves. Lets
+/// [`crate::common::authentication`] short-circuit the
+/// env → file → interactive-prompt cascade instead of asking for
+/// credentials that can never succeed against a site that doesn't exist.
+#[derive(Debug)]
+pub struct SiteNotFound {
+  /// The `X-Manta-Site` value the server rejected. Surfaced in the
+  /// error message and recoverable via `downcast_ref`.
+  pub site: String,
+}
+
+impl std::fmt::Display for SiteNotFound {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(
+      f,
+      "site '{}' is not configured on the manta server. \
+       Check the `site` value in your `cli.toml`.",
+      self.site,
+    )
+  }
+}
+
+impl std::error::Error for SiteNotFound {}
+
 /// Convert a `Result<ResponseValue<T>, Error<E>>` from the
 /// progenitor-generated client into an `anyhow::Result<T>`.
 ///

--- a/crates/manta-cli/src/http_client/mod.rs
+++ b/crates/manta-cli/src/http_client/mod.rs
@@ -39,7 +39,9 @@ mod console;
 mod streaming;
 mod wire;
 
-pub use client::{AuthServerUnreachable, MantaClient, OpenApiResultExt};
+pub use client::{
+  AuthServerUnreachable, MantaClient, OpenApiResultExt, SiteNotFound,
+};
 pub(super) use wire::ws_base_url;
 
 #[cfg(test)]

--- a/crates/manta-server/src/server/handlers/auth.rs
+++ b/crates/manta-server/src/server/handlers/auth.rs
@@ -6,12 +6,17 @@
 //! `crate::server::auth_middleware`; this file just maps requests to
 //! [`crate::service::auth`].
 //!
-//! Every auth failure surfaces a generic `401 invalid credentials` so
-//! the response never reveals whether a username exists, whether a
-//! site is configured, or what the backend actually rejected. The
-//! specific reason is captured server-side with `tracing::warn!` and
-//! sent to the audit channel when one is configured on
-//! [`ServerState`].
+//! An unknown `X-Manta-Site` is reported explicitly as `404 Not
+//! Found` — consistent with every authenticated endpoint, which 404s
+//! on an unknown site during [`crate::server::handlers::RequestCtx`]
+//! extraction — so the CLI can fail fast instead of prompting for
+//! credentials that can never succeed.
+//!
+//! Every *other* auth failure surfaces a generic `401 invalid
+//! credentials` so the response never reveals whether a username
+//! exists or what the backend actually rejected. The specific reason
+//! is captured server-side with `tracing::warn!` and sent to the
+//! audit channel when one is configured on [`ServerState`].
 
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -30,13 +35,28 @@ use manta_shared::types::auth::{
 use super::{ErrorResponse, ServerState, SiteHeader, SiteName};
 use crate::service;
 
-/// Single generic 401 surfaced to clients for any `/auth/*` failure.
-/// Detail stays server-side in `tracing::warn!`.
+/// Single generic 401 surfaced to clients for any `/auth/*`
+/// *credential* failure. Detail stays server-side in `tracing::warn!`.
 fn generic_invalid_credentials() -> (StatusCode, Json<ErrorResponse>) {
   (
     StatusCode::UNAUTHORIZED,
     Json(ErrorResponse {
       error: "invalid credentials".to_string(),
+    }),
+  )
+}
+
+/// `404` returned when the `X-Manta-Site` header names a site that is
+/// not configured on this server. Unlike credential failures (which
+/// stay a generic 401), an unknown site is reported explicitly so the
+/// CLI can fail fast instead of prompting for credentials that can
+/// never succeed. Matches the 404 every authenticated endpoint already
+/// returns for an unknown site.
+fn site_not_found(site: &str) -> (StatusCode, Json<ErrorResponse>) {
+  (
+    StatusCode::NOT_FOUND,
+    Json(ErrorResponse {
+      error: format!("site '{site}' not found"),
     }),
   )
 }
@@ -48,6 +68,7 @@ fn generic_invalid_credentials() -> (StatusCode, Json<ErrorResponse>) {
   responses(
     (status = 200, description = "Token issued", body = AuthTokenResponse),
     (status = 401, description = "Invalid credentials", body = ErrorResponse),
+    (status = 404, description = "Unknown site", body = ErrorResponse),
     (status = 429, description = "Rate limit exceeded", body = ErrorResponse),
     (status = 500, description = "Internal error", body = ErrorResponse),
   )
@@ -61,7 +82,7 @@ pub async fn auth_token(
 ) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
   let infra = state.infra_context(&site_name).map_err(|e| {
     tracing::warn!("auth_token: site lookup failed: {}", e);
-    generic_invalid_credentials()
+    site_not_found(&site_name)
   })?;
   let source_ip = peer.ip().to_string();
 
@@ -119,6 +140,7 @@ pub async fn auth_token(
   responses(
     (status = 200, description = "Token is valid"),
     (status = 401, description = "Token rejected", body = ErrorResponse),
+    (status = 404, description = "Unknown site", body = ErrorResponse),
     (status = 429, description = "Rate limit exceeded", body = ErrorResponse),
     (status = 500, description = "Internal error", body = ErrorResponse),
   )
@@ -131,7 +153,7 @@ pub async fn auth_validate(
 ) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
   let infra = state.infra_context(&site_name).map_err(|e| {
     tracing::warn!("auth_validate: site lookup failed: {}", e);
-    generic_invalid_credentials()
+    site_not_found(&site_name)
   })?;
   tracing::info!(site = %site_name, "auth_validate: token check requested");
   match service::auth::validate_api_token(&infra, &req.token).await {

--- a/crates/manta-server/src/server/handlers/auth.rs
+++ b/crates/manta-server/src/server/handlers/auth.rs
@@ -6,11 +6,18 @@
 //! `crate::server::auth_middleware`; this file just maps requests to
 //! [`crate::service::auth`].
 //!
-//! An unknown `X-Manta-Site` is reported explicitly as `404 Not
-//! Found` — consistent with every authenticated endpoint, which 404s
-//! on an unknown site during [`crate::server::handlers::RequestCtx`]
-//! extraction — so the CLI can fail fast instead of prompting for
-//! credentials that can never succeed.
+//! An unknown `X-Manta-Site` is reported explicitly as `404 Not Found`
+//! so the CLI can fail fast instead of prompting for credentials that
+//! can never succeed. This is a deliberate trade-off: because `/auth/*`
+//! takes no bearer token, it lets an *unauthenticated* caller tell a
+//! configured site (401) from an unknown one (404) — reversing this
+//! module's former "reveal nothing about site config" stance. It is
+//! considered acceptable because site names are not secrets and the
+//! per-IP rate limiter in [`crate::server::auth_middleware`] bounds
+//! enumeration. (The authenticated endpoints already expose the same
+//! distinction once *any* syntactically-valid bearer header is present,
+//! since [`crate::server::handlers::RequestCtx`] does the site lookup
+//! before the token is validated against the backend.)
 //!
 //! Every *other* auth failure surfaces a generic `401 invalid
 //! credentials` so the response never reveals whether a username
@@ -50,8 +57,9 @@ fn generic_invalid_credentials() -> (StatusCode, Json<ErrorResponse>) {
 /// not configured on this server. Unlike credential failures (which
 /// stay a generic 401), an unknown site is reported explicitly so the
 /// CLI can fail fast instead of prompting for credentials that can
-/// never succeed. Matches the 404 every authenticated endpoint already
-/// returns for an unknown site.
+/// never succeed. This intentionally reveals site existence to
+/// unauthenticated callers — see the module-level docs for the
+/// trade-off.
 fn site_not_found(site: &str) -> (StatusCode, Json<ErrorResponse>) {
   (
     StatusCode::NOT_FOUND,

--- a/crates/manta-server/tests/server_routes.rs
+++ b/crates/manta-server/tests/server_routes.rs
@@ -688,6 +688,11 @@ async fn auth_validate_unknown_site_returns_404() {
     .await
     .unwrap();
   assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+  let body = body_string(resp.into_body()).await;
+  assert!(
+    body.contains("nonexistent-site"),
+    "404 body should name the missing site, got: {body}"
+  );
 }
 
 #[tokio::test]

--- a/crates/manta-server/tests/server_routes.rs
+++ b/crates/manta-server/tests/server_routes.rs
@@ -125,6 +125,26 @@ fn post_json(uri: &str, body: &str) -> Request<Body> {
     .unwrap()
 }
 
+/// Build an **unauthenticated** POST to a public `/auth/*` endpoint
+/// for an arbitrary `X-Manta-Site`. No Bearer token (these endpoints
+/// are how a token is obtained). The `ConnectInfo` extension is
+/// injected so `auth_token`'s `ConnectInfo<SocketAddr>` extractor
+/// resolves under `oneshot` (which doesn't set it) and the handler
+/// body — where the site lookup lives — actually runs.
+fn post_auth(uri: &str, site: &str, body: &str) -> Request<Body> {
+  let mut req = Request::builder()
+    .method(Method::POST)
+    .uri(uri)
+    .header(header::CONTENT_TYPE, "application/json")
+    .header("X-Manta-Site", site)
+    .body(Body::from(body.to_string()))
+    .unwrap();
+  req.extensions_mut().insert(axum::extract::ConnectInfo(
+    "127.0.0.1:65000".parse::<std::net::SocketAddr>().unwrap(),
+  ));
+  req
+}
+
 // ---------------------------------------------------------------------------
 // Health check
 // ---------------------------------------------------------------------------
@@ -625,6 +645,79 @@ async fn console_session_without_auth_returns_401() {
     .oneshot(ws_upgrade("/api/v1/sessions/my-session/console"))
     .await
     .unwrap();
+  assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+// ---------------------------------------------------------------------------
+// Auth endpoints — unknown site is reported as 404 (issue #102)
+//
+// The public `/auth/*` endpoints used to collapse every failure
+// (including "site not configured") into a generic 401. They now 404
+// on an unknown `X-Manta-Site`, matching every authenticated endpoint,
+// so the CLI can fail fast instead of prompting for credentials that
+// can never succeed. A *known* site must NOT 404 — the backend call is
+// attempted and its failure stays a generic 401.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn auth_token_unknown_site_returns_404() {
+  let resp = router()
+    .oneshot(post_auth(
+      "/api/v1/auth/token",
+      "nonexistent-site",
+      r#"{"username":"alice","password":"hunter2"}"#,
+    ))
+    .await
+    .unwrap();
+  assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+  let body = body_string(resp.into_body()).await;
+  assert!(
+    body.contains("nonexistent-site"),
+    "404 body should name the missing site, got: {body}"
+  );
+}
+
+#[tokio::test]
+async fn auth_validate_unknown_site_returns_404() {
+  let resp = router()
+    .oneshot(post_auth(
+      "/api/v1/auth/validate",
+      "nonexistent-site",
+      r#"{"token":"some-token"}"#,
+    ))
+    .await
+    .unwrap();
+  assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn auth_token_known_site_is_not_404() {
+  // Site "test" exists; the stub backend at http://stub.invalid can't
+  // be reached, so the credential exchange fails — but as a generic
+  // 401, never a 404 (which is reserved for unknown sites).
+  let resp = router()
+    .oneshot(post_auth(
+      "/api/v1/auth/token",
+      "test",
+      r#"{"username":"alice","password":"hunter2"}"#,
+    ))
+    .await
+    .unwrap();
+  assert_ne!(resp.status(), StatusCode::NOT_FOUND);
+  assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn auth_validate_known_site_is_not_404() {
+  let resp = router()
+    .oneshot(post_auth(
+      "/api/v1/auth/validate",
+      "test",
+      r#"{"token":"some-token"}"#,
+    ))
+    .await
+    .unwrap();
+  assert_ne!(resp.status(), StatusCode::NOT_FOUND);
   assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 }
 


### PR DESCRIPTION
Targeting a site that isn't configured on the server used to prompt for a
username/password (up to 3×) and then fail with a generic `401 invalid
credentials`. The server has the list of configured sites, so it should fail
fast with a clear "site not found".

**Root cause:** the public `/auth/{token,validate}` handlers deliberately
collapsed *every* failure — including "site not in `ServerState.sites`" — into
one generic `401`. Meanwhile every *authenticated* endpoint already returns
`404` for an unknown `X-Manta-Site` (via the `RequestCtx` extractor →
`to_handler_error`). The auth endpoints were the inconsistent outlier.

A server-only fix isn't enough: the CLI only special-cases "server
unreachable" today, so a 404 would still fall through the credential cascade
and re-prompt. So this changes both halves.

Closes #102