### PR TITLE
ci: gate checked-in openapi.json against the live server spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,39 +122,64 @@ jobs:
       run: cargo install cargo-machete --version 0.9.2 --locked
     - name: Run cargo machete
       run: cargo machete
-    # On pull_request: verify that the checked-in man pages and shell-
-    # completion scripts are in sync with the current clap definition.
-    # `build.rs` only regenerates them when MANTA_REGENERATE_DOCS=1 is
-    # set, so a clap change a contributor forgot to regenerate would
-    # otherwise ship stale docs. Fail loudly so the PR author knows to
-    # run the regen + commit locally.
-    - name: Verify generated docs are up to date (PRs only)
+    # On pull_request: verify that three checked-in generated artifacts
+    # are in sync with their source of truth:
+    #   - crates/manta-cli/openapi.json        ← the server's #[utoipa::path]
+    #     annotations, emitted by `manta-server --emit-openapi`;
+    #   - crates/manta-cli/man                 ← the clap definition;
+    #   - crates/manta-cli/autocomplete_shell_scripts ← the clap definition.
+    # None of these break the build when stale — the CLI happily
+    # regenerates its client from a stale spec, and `build.rs` only
+    # regenerates man/completions when MANTA_REGENERATE_DOCS=1 — so a
+    # contributor who edits a handler's #[utoipa::path] / wire-type
+    # docstring or the clap surface without regenerating ships drift
+    # silently. (This is exactly how openapi.json fell six versions
+    # behind before a later PR swept the whole backlog into one diff.)
+    # Fail loudly so the PR author regenerates + commits locally.
+    - name: Verify generated artifacts are up to date (PRs only)
       if: github.event_name == 'pull_request'
       run: |
+        cargo run -p manta-server -- --emit-openapi > crates/manta-cli/openapi.json
         MANTA_REGENERATE_DOCS=1 cargo build -p manta-cli
+        # Diff each artifact group separately so the failure names only
+        # the one(s) that actually drifted and prints just the matching
+        # regen command. Accumulate into `status` instead of exiting on
+        # the first miss, so a PR that touched both surfaces sees both.
+        status=0
+        if ! git diff --exit-code -- crates/manta-cli/openapi.json; then
+          echo "ERROR: OpenAPI spec (crates/manta-cli/openapi.json) is out of date."
+          echo "Regenerate it and commit the diff:"
+          echo "  cargo run -p manta-server -- --emit-openapi > crates/manta-cli/openapi.json"
+          status=1
+        fi
         if ! git diff --exit-code -- crates/manta-cli/man crates/manta-cli/autocomplete_shell_scripts; then
           echo "ERROR: man pages or shell completions are out of date."
-          echo "Run 'MANTA_REGENERATE_DOCS=1 cargo build -p manta-cli' and commit the diff."
-          exit 1
+          echo "Regenerate them and commit the diff:"
+          echo "  MANTA_REGENERATE_DOCS=1 cargo build -p manta-cli"
+          status=1
         fi
-    # On push to main: regenerate, and if anything actually changed,
-    # commit + push the result back. Without this, cargo-release's
-    # version bumps leave manta.1's embedded version string stale on
-    # every release until someone notices the next PR failing. The
-    # `[skip ci]` marker on the auto-commit prevents this workflow
-    # from re-triggering itself.
-    - name: Regenerate and commit generated docs (main only)
+        exit $status
+    # On push to main: regenerate all three artifacts, and if anything
+    # actually changed, commit + push the result back. Without this,
+    # cargo-release's version bumps leave both manta.1's embedded
+    # version string and openapi.json's `info.version` stale on every
+    # release until someone notices the next PR failing — `info.version`
+    # tracks CARGO_PKG_VERSION, so it changes on every bump even with no
+    # API change. The `[skip ci]` marker on the auto-commit prevents
+    # this workflow from re-triggering itself.
+    - name: Regenerate and commit generated artifacts (main only)
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       run: |
+        cargo run -p manta-server -- --emit-openapi > crates/manta-cli/openapi.json
         MANTA_REGENERATE_DOCS=1 cargo build -p manta-cli
-        if git diff --quiet -- crates/manta-cli/man crates/manta-cli/autocomplete_shell_scripts; then
-          echo "Generated docs already in sync; nothing to commit."
+        if git diff --quiet -- crates/manta-cli/openapi.json crates/manta-cli/man crates/manta-cli/autocomplete_shell_scripts; then
+          echo "Generated artifacts already in sync; nothing to commit."
           exit 0
         fi
         git config user.name  "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        git add crates/manta-cli/man crates/manta-cli/autocomplete_shell_scripts
-        git commit -m "chore(cli): regenerate man pages + shell completions [skip ci]"
+        git add crates/manta-cli/openapi.json crates/manta-cli/man crates/manta-cli/autocomplete_shell_scripts
+        git commit -m "chore(cli): regenerate OpenAPI spec + man pages + shell completions [skip ci]"
         git push origin HEAD:main
 
   # Validate that both Dockerfiles still build and produce a runnable

--- a/crates/manta-cli/openapi.json
+++ b/crates/manta-cli/openapi.json
@@ -1118,7 +1118,6 @@
           "groups"
         ],
         "summary": "GET /groups/available — list HSM group names the token can access.",
-        "description": "Backs CLI authorization helpers that used to call\n`backend.get_group_name_available` directly.",
         "operationId": "get_available_groups",
         "parameters": [
           {


### PR DESCRIPTION
`openapi.json` is generated from the server but checked into git and only consumed at build time, so a stale spec still builds — drift goes unnoticed. This folds the spec into the existing generated-artifacts CI steps: PRs fail if it's out of sync (with a per-artifact message pointing to the right regen command), and main auto-commits the regen.